### PR TITLE
feat: add npm script to start mysql docker container

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "standard && tap test/*.test.js",
-    "docker": "docker run -d -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes mysql"
+    "mysql": "docker run -d -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes --rm mysql"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Fastify Mysql connection plugin",
   "main": "index.js",
   "scripts": {
-    "test": "standard && tap test/*.test.js"
+    "test": "standard && tap test/*.test.js",
+    "docker": "docker run -d -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes mysql"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- add npm script to start docker container and bind to local 3306 port, allow empty password for root because we're using user `root` and empty password in test scripts. Fixes #8 