### PR TITLE
Drop Node 6, prep for new major

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 
 node_js:
+  - "13"
   - "12"
   - "10"
   - "8"
-  - "6"
 
 services:
   - msyql

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@
 Fastify MySQL connection plugin, with this you can share the same MySQL connection pool in every part of your server.
 Under the hood the [mysql2](https://github.com/sidorares/node-mysql2) is used, the options that you pass to `register` will be passed to the MySQL pool builder.
 
-**Disclaimer:**
-**`MySQL 8.x` databases are not compatible !** This plugin is compatible with `MySQL 5.5.x`, `MySQL 5.7.x` and `MariaDB` databases.
-
-
 ## Install
 ```
 npm i fastify-mysql --save

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "test": "standard && tap test/*.test.js",
     "mariadb": "docker run -d -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes --rm mariadb:10.1",
-    "mysql": "docker run -d -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes --rm mysql:5.5",
-    "mysql:5.7": "docker run -d -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes --rm mysql:5.7"
+    "mysql": "npm run mysql:8.0",
+    "mysql:5.7": "docker run -d -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes --rm mysql:5.7",
+    "mysql:5.5": "docker run -d -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes --rm mysql:5.5",
+    "mysql:8.0": "docker run -d -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes --rm mysql:8.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

Drop support for Node 6 because mysql2@2 does not include it in its .travis.yml. Removes the disclaimer about MySql 8.x, and add it as an npm script to run it.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
