### PR TITLE
Add types definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Under the hood the [mysql2](https://github.com/sidorares/node-mysql2) is used, t
 npm i fastify-mysql --save
 ```
 ## Usage
-Add it to you project with `register`. You can pass to `register` method all of `ConnectionOptions` and `PoolOptions` properties from mysql2 package along with properties from plugin: `type`, `name`, `usePromise` and `connectionString`.
+Add it to your project with `register`. You can pass as options all of `ConnectionOptions` and `PoolOptions` properties from mysql2 package along with properties from plugin: `type`, `name`, `usePromise` and `connectionString`.
 
 This plugin will add the `mysql` namespace in your Fastify instance, with the following properties:
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Under the hood the [mysql2](https://github.com/sidorares/node-mysql2) is used, t
 npm i fastify-mysql --save
 ```
 ## Usage
-Add it to you project with `register` and you are done!
+Add it to you project with `register`. You can pass to `register` method all of `ConnectionOptions` and `PoolOptions` properties from mysql2 package along with properties from plugin: `type`, `name`, `usePromise` and `connectionString`.
+
 This plugin will add the `mysql` namespace in your Fastify instance, with the following properties:
 ```
 pool: the pool instance

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,9 +3,9 @@
 
 import { Server, IncomingMessage, ServerResponse } from "http";
 import fastify from "fastify";
-import mysql2, { ConnectionOptions } from "mysql2";
+import mysql2, { ConnectionOptions, PoolOptions } from "mysql2";
 
-export declare type FastifyMysqlOptions = ConnectionOptions & {
+export declare type FastifyMysqlOptions = ConnectionOptions & PoolOptions & {
   /**
    * Conenction type. If it is set up to something different than "connection", plugin will use mysql poll as client.
    */
@@ -24,7 +24,7 @@ export declare type FastifyMysqlOptions = ConnectionOptions & {
   /**
    * Value which will be used to connect to mysql.
    */
-  connectionString?: connectionString;
+  connectionString?: string;
 };
 
 declare const fastifyMysql: fastify.Plugin<

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,37 @@
+/// <reference types="node" />
+// Definitions by: Paweł Mrowiec <https://github.com/mrowa96>
+
+import { Server, IncomingMessage, ServerResponse } from "http";
+import fastify from "fastify";
+import mysql2, { ConnectionOptions } from "mysql2";
+
+export declare type FastifyMysqlOptions = ConnectionOptions & {
+  /**
+   * Conenction type. If it is set up to something different than "connection", plugin will use mysql poll as client.
+   */
+  type?: "connection";
+
+  /**
+   * Plugin instance name.
+   */
+  name?: string;
+
+  /**
+   * If equal to true, plugin will use mysql2/promise instead of mysql2.
+   */
+  usePromise?: boolean;
+
+  /**
+   * Value which will be used to connect to mysql.
+   */
+  connectionString?: connectionString;
+};
+
+declare const fastifyMysql: fastify.Plugin<
+  Server,
+  IncomingMessage,
+  ServerResponse,
+  FastifyMysqlOptions
+>;
+
+export default fastifyMysql;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "mysql2": "^2.0.0"
   },
   "devDependencies": {
+    "@types/mysql2": "github:types/mysql2",
     "fastify": "^2.3.0",
     "standard": "^14.0.0",
     "tap": "^12.7.0"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Fastify Mysql connection plugin",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "standard && tap test/*.test.js",
     "mariadb": "docker run -d -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes --rm mariadb:10.1",


### PR DESCRIPTION
Types definitions were missing from this package, so I decided to add them.
Definitions are from gtihub, because unfortunately https://github.com/types/mysql2 is not published to npm.
