### PR TITLE
resolve fastify-mysql promise causing tap timeouts #33

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,13 @@ function fastifyMysql (fastify, options, next) {
 
     const client = connectionType !== 'connection' ? db.pool : db.connection
 
-    fastify.addHook('onClose', (fastify, done) => client.end(done))
+    if (usePromise) {
+      fastify.addHook('onClose', async (fastify, done) => {
+        await client.end(); done()
+      })
+    } else {
+      fastify.addHook('onClose', (fastify, done) => client.end(done))
+    }
 
     if (name) {
       if (!fastify.mysql) {

--- a/index.js
+++ b/index.js
@@ -17,9 +17,15 @@ function fastifyMysql (fastify, options, next) {
 
     const client = connectionType !== 'connection' ? db.pool : db.connection
 
-    fastify.addHook('onClose', async (fastify, done) => {
-      await client.end(); done()
-    })
+    if (usePromise) {
+      fastify.addHook('onClose', async (fastify, done) => {
+        client.end().then(done).catch(done)
+      })
+    } else {
+      fastify.addHook('onClose', async (fastify, done) => {
+        client.end(done)
+      })
+    }
 
     if (name) {
       if (!fastify.mysql) {

--- a/index.js
+++ b/index.js
@@ -18,13 +18,9 @@ function fastifyMysql (fastify, options, next) {
     const client = connectionType !== 'connection' ? db.pool : db.connection
 
     if (usePromise) {
-      fastify.addHook('onClose', async (fastify, done) => {
-        client.end().then(done).catch(done)
-      })
+      fastify.addHook('onClose', (fastify, done) => client.end().then(done).catch(done))
     } else {
-      fastify.addHook('onClose', async (fastify, done) => {
-        client.end(done)
-      })
+      fastify.addHook('onClose', (fastify, done) => client.end(done))
     }
 
     if (name) {

--- a/index.js
+++ b/index.js
@@ -17,13 +17,9 @@ function fastifyMysql (fastify, options, next) {
 
     const client = connectionType !== 'connection' ? db.pool : db.connection
 
-    if (usePromise) {
-      fastify.addHook('onClose', async (fastify, done) => {
-        await client.end(); done()
-      })
-    } else {
-      fastify.addHook('onClose', (fastify, done) => client.end(done))
-    }
+    fastify.addHook('onClose', async (fastify, done) => {
+      await client.end(); done()
+    })
 
     if (name) {
       if (!fastify.mysql) {

--- a/test/closing.test.js
+++ b/test/closing.test.js
@@ -1,0 +1,51 @@
+const test = require('tap').test
+const Fastify = require('fastify')
+const fastifyMysql = require('../index')
+
+test('callback connection', (t) => {
+  let fastify = null
+
+  fastify = Fastify()
+  fastify.register(fastifyMysql, {
+    type: 'connection',
+    connectionString: 'mysql://root@localhost/mysql'
+  })
+
+  fastify.ready((err) => {
+    t.error(err)
+
+    fastify.mysql.query('SELECT 1 AS `ping`', (err, results) => {
+      t.error(err)
+      t.ok(results[0].ping === 1)
+
+      fastify.close((closeErr) => {
+        t.error(closeErr)
+        t.end()
+      })
+    })
+  })
+})
+
+test('promise connection', (t) => {
+  let fastify = null
+
+  fastify = Fastify()
+  fastify.register(fastifyMysql, {
+    promise: true,
+    type: 'connection',
+    connectionString: 'mysql://root@localhost/mysql'
+  })
+
+  fastify.ready((err) => {
+    t.error(err)
+
+    fastify.mysql.query('SELECT 1 AS `ping`').then(([results]) => {
+      t.ok(results[0].ping === 1)
+
+      fastify.close((closeErr) => {
+        t.error(closeErr)
+        t.end()
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->
## Issue

While developing an app using `fastify-mysql`, I observed that my tests were timing out. If I disable `promise`, the same tests were not timing out. I tried but could not replicate this using a standalone test. It seems like `fastify` is waiting for MySQL to close the connection.

As mentioned in [issue #33] (https://github.com/fastify/fastify-mysql/issues/33) changing the code for the onClose event also resolved this issue for me. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

```
> fastify-mysql@1.0.0 test /Users/Jerry/Code/issues/fastify-mysql
> standard && tap test/*.test.js

test/connection.test.js ............................. 38/38
test/initialization.test.js ......................... 19/19
test/pool.promise.test.js ........................... 13/13
test/pool.test.js ................................... 35/35
total ............................................. 105/105

  105 passing (2s)

  ok
```