### PR TITLE
feat: export RowDataPacket, ResultSetHeader, ProcedureCallPacket from MySQL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,64 @@ declare module 'fastify' {
 }
 ```
 
+#### MySQLRowDataPacket 
+Ability to add type for return data using mysql2 [RowDataPacket](https://sidorares.github.io/node-mysql2/docs/documentation/typescript-examples#rowdatapacket). 
+
+```
+const fastifyMysql, { MySQLRowDataPacket } from '@fastify/mysql'
+
+const app = fastify();
+
+app.register(fastifyMysql, {
+  connectionString: "mysql://root@localhost/mysql",
+});
+
+app.get("/", async () => {
+  const connection = app.mysql;
+
+  // SELECT
+  const [rows, fields] = await connection.query<MySQLRowDataPacket[]>(
+    "SELECT 1 + 1 AS `test`;",
+  );
+
+  /**
+   * @rows: [ { test: 2 } ]
+   */
+  return rows[0];
+});
+```
+
+#### MySQLResultSetHeader 
+Ability to add type for return data using mysql2 [ResultSetHeader](https://sidorares.github.io/node-mysql2/docs/documentation/typescript-examples#resultsetheader). 
+
+```
+const fastifyMysql, { MySQLResultSetHeader } from '@fastify/mysql'
+
+const app = fastify();
+
+app.register(fastifyMysql, {
+  connectionString: "mysql://root@localhost/mysql",
+});
+
+app.get("/", async () => {
+  const connection = app.mysql;
+  const result = await connection.query<MySQLResultSetHeader>("SET @1 = 1");
+
+  /**
+   * @result: ResultSetHeader {
+      fieldCount: 0,
+      affectedRows: 0,
+      insertId: 0,
+      info: '',
+      serverStatus: 2,
+      warningStatus: 0,
+      changedRows: 0
+    }
+   */
+  return result
+});
+```
+
 ## Acknowledgements
 
 This project is kindly sponsored by:

--- a/README.md
+++ b/README.md
@@ -194,6 +194,83 @@ app.get("/", async () => {
 });
 ```
 
+##### isMySQLPool
+Method to check if fastify decorator, mysql is type of [MySQLPool](https://github.com/fastify/fastify-mysql/blob/master/types/index.d.ts#L32)
+
+```typescript
+const app = fastify();
+app
+  .register(fastifyMysql, {
+    connectionString: "mysql://root@localhost/mysql",
+  })
+  .after(function (err) {
+    if (isMySQLPool(app.mysql)) {
+      const mysql = app.mysql
+      mysql.getConnection(function (err, con) {
+        con.release();
+      });
+      mysql.pool.end();
+    }
+  })
+```
+
+
+##### isMySQLPromisePool 
+Method to check if fastify decorator, mysql is type of [MySQLPromisePool](https://github.com/fastify/fastify-mysql/blob/master/types/index.d.ts#L43)
+
+```typescript
+app
+  .register(fastifyMysql, {
+    promise: true,
+    connectionString: "mysql://root@localhost/mysql",
+  })
+  .after(async function (err) {
+    if (isMySQLPromisePool(app.mysql)) {
+      const mysql = app.mysql
+      const con = await mysql.getConnection();
+      con.release();
+      mysql.pool.end();
+    }
+  });
+```
+
+
+##### isMySQLConnection 
+Method to check if fastify decorator, mysql is type of [MySQLConnection](https://github.com/fastify/fastify-mysql/blob/master/types/index.d.ts#L28)
+
+```typescript
+app
+  .register(fastifyMysql, {
+    type: "connection",
+    connectionString: "mysql://root@localhost/mysql",
+  })
+  .after(async function (err) {
+    if (isMySQLConnection(app.mysql)) {
+      const mysql = app.mysql
+      mysql.connection.end();
+    }
+  });
+```
+
+
+##### isMySQLPromiseConnection 
+Method to check if fastify decorator, mysql is type of [MySQLPromiseConnection](https://github.com/fastify/fastify-mysql/blob/master/types/index.d.ts#L36)
+
+```typescript
+app
+  .register(fastifyMysql, {
+    type: "connection",
+    promise: true,
+    connectionString: "mysql://root@localhost/mysql",
+  })
+  .after(async function (err) {
+    if (isMySQLPromiseConnection(app.mysql)) {
+      const mysql = app.mysql
+      mysql.connection.end();
+    }
+  });
+```
+
 ## Acknowledgements
 
 This project is kindly sponsored by:

--- a/index.js
+++ b/index.js
@@ -100,24 +100,28 @@ function _createConnection ({ connectionType, options, usePromise }, cb) {
   }
 }
 
-function isMySQLPool (obj) {
-  if (!('pool' in obj)) return false
+function isMySQLPoolOrPromisePool (obj) {
   return obj && typeof obj.query === 'function' && typeof obj.execute === 'function' && typeof obj.getConnection === 'function' && typeof obj.pool === 'object'
+}
+
+function isMySQLConnectionOrPromiseConnection (obj) {
+  return obj && typeof obj.query === 'function' && typeof obj.execute === 'function' && typeof obj.connection === 'object'
+}
+
+function isMySQLPool (obj) {
+  return isMySQLPoolOrPromisePool(obj) && typeof obj.pool.promise === 'function'
 }
 
 function isMySQLPromisePool (obj) {
-  if (!('pool' in obj)) return false
-  return obj && typeof obj.query === 'function' && typeof obj.execute === 'function' && typeof obj.getConnection === 'function' && typeof obj.pool === 'object'
+  return isMySQLPoolOrPromisePool(obj) && typeof obj.threadId === 'number' && obj.pool.promise === undefined
 }
 
 function isMySQLConnection (obj) {
-  if (!('connection' in obj)) return false
-  return obj && typeof obj.query === 'function' && typeof obj.execute === 'function' && obj.connection && typeof obj.connection === 'object'
+  return isMySQLConnectionOrPromiseConnection(obj) && typeof obj.connection.promise === 'function' && typeof obj.connection.authorized === 'boolean'
 }
 
 function isMySQLPromiseConnection (obj) {
-  if (!('connection' in obj)) return false
-  return obj && typeof obj.query === 'function' && typeof obj.execute === 'function' && obj.connection && typeof obj.connection === 'object'
+  return isMySQLConnectionOrPromiseConnection(obj) && typeof obj.threadId === 'number' && obj.connection.promise === undefined
 }
 
 module.exports = fp(fastifyMysql, {

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function isMySQLPool (obj) {
 }
 
 function isMySQLPromisePool (obj) {
-  return isMySQLPoolOrPromisePool(obj) && typeof obj.threadId === 'number' && obj.pool.promise === undefined
+  return isMySQLPoolOrPromisePool(obj) && obj.pool.promise === undefined
 }
 
 function isMySQLConnection (obj) {
@@ -121,7 +121,7 @@ function isMySQLConnection (obj) {
 }
 
 function isMySQLPromiseConnection (obj) {
-  return isMySQLConnectionOrPromiseConnection(obj) && typeof obj.threadId === 'number' && obj.connection.promise === undefined
+  return isMySQLConnectionOrPromiseConnection(obj) && obj.connection.promise === undefined
 }
 
 module.exports = fp(fastifyMysql, {

--- a/index.js
+++ b/index.js
@@ -100,9 +100,33 @@ function _createConnection ({ connectionType, options, usePromise }, cb) {
   }
 }
 
+function isMySQLPool (obj) {
+  if (!('pool' in obj)) return false
+  return obj && typeof obj.query === 'function' && typeof obj.execute === 'function' && typeof obj.getConnection === 'function' && typeof obj.pool === 'object'
+}
+
+function isMySQLPromisePool (obj) {
+  if (!('pool' in obj)) return false
+  return obj && typeof obj.query === 'function' && typeof obj.execute === 'function' && typeof obj.getConnection === 'function' && typeof obj.pool === 'object'
+}
+
+function isMySQLConnection (obj) {
+  if (!('connection' in obj)) return false
+  return obj && typeof obj.query === 'function' && typeof obj.execute === 'function' && obj.connection && typeof obj.connection === 'object'
+}
+
+function isMySQLPromiseConnection (obj) {
+  if (!('connection' in obj)) return false
+  return obj && typeof obj.query === 'function' && typeof obj.execute === 'function' && obj.connection && typeof obj.connection === 'object'
+}
+
 module.exports = fp(fastifyMysql, {
   fastify: '4.x',
   name: '@fastify/mysql'
 })
 module.exports.default = fastifyMysql
 module.exports.fastifyMysql = fastifyMysql
+module.exports.isMySQLPool = isMySQLPool
+module.exports.isMySQLPromisePool = isMySQLPromisePool
+module.exports.isMySQLConnection = isMySQLConnection
+module.exports.isMySQLPromiseConnection = isMySQLPromiseConnection

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -200,7 +200,7 @@ test('promise connection', (t) => {
 })
 
 test('isMySQLConnection is true', (t) => {
-  t.plan(3)
+  t.plan(5)
   const fastify = Fastify()
   fastify.register(fastifyMysql, {
     type: 'connection',
@@ -210,6 +210,8 @@ test('isMySQLConnection is true', (t) => {
     t.error(err)
     t.equal(isMySQLConnection(fastify.mysql), true)
     t.equal(isMySQLPool(fastify.mysql), false)
+    t.equal(isMySQLPromiseConnection(fastify.mysql), false)
+    t.equal(isMySQLPromisePool(fastify.mysql), false)
     t.end()
   })
   fastify.close()
@@ -227,6 +229,8 @@ test('isMySQLPromiseConnection is true', (t) => {
     t.error(err)
     t.equal(isMySQLPromiseConnection(fastify.mysql), true)
     t.equal(isMySQLPromisePool(fastify.mysql), false)
+    t.equal(isMySQLConnection(fastify.mysql), false)
+    t.equal(isMySQLPool(fastify.mysql), false)
     t.end()
   })
   fastify.close()

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -3,6 +3,7 @@
 const test = require('tap').test
 const Fastify = require('fastify')
 const fastifyMysql = require('../index')
+const { isMySQLPool, isMySQLPromisePool, isMySQLConnection, isMySQLPromiseConnection } = fastifyMysql
 
 test('fastify.mysql namespace should exist', (t) => {
   const fastify = Fastify()
@@ -196,6 +197,39 @@ test('promise connection', (t) => {
   })
 
   t.end()
+})
+
+test('isMySQLConnection is true', (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+  fastify.register(fastifyMysql, {
+    type: 'connection',
+    connectionString: 'mysql://root@localhost/mysql'
+  })
+  fastify.ready((err) => {
+    t.error(err)
+    t.equal(isMySQLConnection(fastify.mysql), true)
+    t.equal(isMySQLPool(fastify.mysql), false)
+    t.end()
+  })
+  fastify.close()
+})
+
+test('isMySQLPromiseConnection is true', (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+  fastify.register(fastifyMysql, {
+    promise: true,
+    type: 'connection',
+    connectionString: 'mysql://root@localhost/mysql'
+  })
+  fastify.ready((err) => {
+    t.error(err)
+    t.equal(isMySQLPromiseConnection(fastify.mysql), true)
+    t.equal(isMySQLPromisePool(fastify.mysql), false)
+    t.end()
+  })
+  fastify.close()
 })
 
 test('Promise: should throw when mysql2 fail to perform operation', (t) => {

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -218,7 +218,7 @@ test('isMySQLConnection is true', (t) => {
 })
 
 test('isMySQLPromiseConnection is true', (t) => {
-  t.plan(3)
+  t.plan(5)
   const fastify = Fastify()
   fastify.register(fastifyMysql, {
     promise: true,

--- a/test/pool.promise.test.js
+++ b/test/pool.promise.test.js
@@ -3,6 +3,7 @@
 const test = require('tap').test
 const Fastify = require('fastify')
 const fastifyMysql = require('../index')
+const { isMySQLPromisePool, isMySQLPromiseConnection } = fastifyMysql
 
 test('promise pool', (t) => {
   let fastify
@@ -81,4 +82,20 @@ test('promise pool', (t) => {
   })
 
   t.end()
+})
+
+test('isMySQLPromisePool is true', (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+  fastify.register(fastifyMysql, {
+    promise: true,
+    connectionString: 'mysql://root@localhost/mysql'
+  })
+  fastify.ready((err) => {
+    t.error(err)
+    t.equal(isMySQLPromisePool(fastify.mysql), true)
+    t.equal(isMySQLPromiseConnection(fastify.mysql), false)
+    t.end()
+  })
+  fastify.close()
 })

--- a/test/pool.promise.test.js
+++ b/test/pool.promise.test.js
@@ -3,7 +3,7 @@
 const test = require('tap').test
 const Fastify = require('fastify')
 const fastifyMysql = require('../index')
-const { isMySQLPromisePool, isMySQLPromiseConnection } = fastifyMysql
+const { isMySQLPromisePool, isMySQLPromiseConnection, isMySQLPool, isMySQLConnection } = fastifyMysql
 
 test('promise pool', (t) => {
   let fastify
@@ -85,7 +85,7 @@ test('promise pool', (t) => {
 })
 
 test('isMySQLPromisePool is true', (t) => {
-  t.plan(3)
+  t.plan(5)
   const fastify = Fastify()
   fastify.register(fastifyMysql, {
     promise: true,
@@ -95,6 +95,8 @@ test('isMySQLPromisePool is true', (t) => {
     t.error(err)
     t.equal(isMySQLPromisePool(fastify.mysql), true)
     t.equal(isMySQLPromiseConnection(fastify.mysql), false)
+    t.equal(isMySQLPool(fastify.mysql), false)
+    t.equal(isMySQLConnection(fastify.mysql), false)
     t.end()
   })
   fastify.close()

--- a/test/pool.test.js
+++ b/test/pool.test.js
@@ -4,7 +4,7 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('fastify')
 const fastifyMysql = require('../index')
-const { isMySQLPool, isMySQLConnection } = fastifyMysql
+const { isMySQLPool, isMySQLPromisePool, isMySQLConnection, isMySQLPromiseConnection } = fastifyMysql
 
 test('fastify.mysql namespace should exist', t => {
   t.plan(9)
@@ -171,7 +171,7 @@ test('synchronous functions', (t) => {
 })
 
 test('isMySQLPool is true', (t) => {
-  t.plan(3)
+  t.plan(5)
   const fastify = Fastify()
   fastify.register(fastifyMysql, {
     connectionString: 'mysql://root@localhost/mysql'
@@ -180,6 +180,8 @@ test('isMySQLPool is true', (t) => {
     t.error(err)
     t.equal(isMySQLPool(fastify.mysql), true)
     t.equal(isMySQLConnection(fastify.mysql), false)
+    t.equal(isMySQLPromisePool(fastify.mysql), false)
+    t.equal(isMySQLPromiseConnection(fastify.mysql), false)
     t.end()
   })
   fastify.close()

--- a/test/pool.test.js
+++ b/test/pool.test.js
@@ -4,6 +4,7 @@ const t = require('tap')
 const test = t.test
 const Fastify = require('fastify')
 const fastifyMysql = require('../index')
+const { isMySQLPool, isMySQLConnection } = fastifyMysql
 
 test('fastify.mysql namespace should exist', t => {
   t.plan(9)
@@ -167,4 +168,19 @@ test('synchronous functions', (t) => {
     fastify.close()
     t.end()
   })
+})
+
+test('isMySQLPool is true', (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+  fastify.register(fastifyMysql, {
+    connectionString: 'mysql://root@localhost/mysql'
+  })
+  fastify.ready((err) => {
+    t.error(err)
+    t.equal(isMySQLPool(fastify.mysql), true)
+    t.equal(isMySQLConnection(fastify.mysql), false)
+    t.end()
+  })
+  fastify.close()
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,6 +19,12 @@ type FastifyMysql = FastifyPluginCallback<fastifyMysql.MySQLOptions>;
 
 declare namespace fastifyMysql {
 
+  type MySQLPoolConnection = MySQLPool | MySQLConnection | MySQLPromisePool | MySQLPromiseConnection;
+  export function isMySQLPool(obj: MySQLPoolConnection): obj is MySQLPool;
+  export function isMySQLPromisePool(obj: MySQLPoolConnection): obj is MySQLPromisePool;
+  export function isMySQLConnection(obj: MySQLPoolConnection): obj is MySQLConnection;
+  export function isMySQLPromiseConnection(obj: MySQLPoolConnection): obj is MySQLPromiseConnection;
+
   // upstream package missed type
   type escapeId = (val: any, forbidQualified?: boolean) => string;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,6 +6,9 @@ import {
   format,
   Pool,
   PoolOptions,
+  ProcedureCallPacket,
+  ResultSetHeader,
+  RowDataPacket,
 } from "mysql2";
 import {
   Connection as PromiseConnection,
@@ -55,6 +58,12 @@ declare namespace fastifyMysql {
     promise?: boolean;
     connectionString?: string;
   }
+
+  export type MySQLProcedureCallPacket<
+    T = [MySQLRowDataPacket[], MySQLResultSetHeader] | MySQLResultSetHeader,
+  > = ProcedureCallPacket<T>
+  export type MySQLResultSetHeader = ResultSetHeader
+  export type MySQLRowDataPacket = RowDataPacket
 
   export const fastifyMysql: FastifyMysql
   export { fastifyMysql as default } 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -7,8 +7,12 @@ import fastifyMysql, {
   MySQLProcedureCallPacket,
   MySQLResultSetHeader,
   MySQLRowDataPacket,
+  isMySQLPromiseConnection,
+  isMySQLConnection,
+  isMySQLPromisePool,
+  isMySQLPool,
 } from "..";
-import {expectType} from 'tsd';
+import { expectType } from 'tsd';
 
 declare module "fastify" {
   interface FastifyInstance {
@@ -26,33 +30,37 @@ app
     connectionString: "mysql://root@localhost/mysql",
   })
   .after(function (err) {
-    const mysql = app.mysql as MySQLPool;
-    mysql.escapeId("foo");
-    mysql.escape("bar");
-    mysql.format("baz");
-    mysql.query("SELECT NOW()", function () {});
-    mysql.execute("SELECT NOW()", function () {});
-    mysql.getConnection(function (err, con) {
+    if (isMySQLPool(app.mysql)) {
+      const mysql = app.mysql
+      mysql.escapeId("foo");
+      mysql.escape("bar");
+      mysql.format("baz");
+      mysql.query("SELECT NOW()", function () {});
+      mysql.execute("SELECT NOW()", function () {});
+      mysql.getConnection(function (err, con) {
+        con.release();
+      });
+      mysql.pool.end();
+    }
+  });
+
+app
+  .register(fastifyMysql, {
+    promise: true,
+    connectionString: "mysql://root@localhost/mysql",
+  })
+  .after(async function (err) {
+    if (isMySQLPromisePool(app.mysql)) {
+      const mysql = app.mysql
+      mysql.escapeId("foo");
+      mysql.escape("bar");
+      mysql.format("baz");
+      await mysql.query("SELECT NOW()");
+      await mysql.execute("SELECT NOW()");
+      const con = await mysql.getConnection();
       con.release();
-    });
-    mysql.pool.end();
-  });
-
-app
-  .register(fastifyMysql, {
-    promise: true,
-    connectionString: "mysql://root@localhost/mysql",
-  })
-  .after(async function (err) {
-    const mysql = app.mysql as MySQLPromisePool;
-    mysql.escapeId("foo");
-    mysql.escape("bar");
-    mysql.format("baz");
-    await mysql.query("SELECT NOW()");
-    await mysql.execute("SELECT NOW()");
-    const con = await mysql.getConnection();
-    con.release();
-    mysql.pool.end();
+      mysql.pool.end();
+    }
   });
 
 app
@@ -61,13 +69,15 @@ app
     connectionString: "mysql://root@localhost/mysql",
   })
   .after(async function (err) {
-    const mysql = app.mysql as MySQLConnection;
-    mysql.escapeId("foo");
-    mysql.escape("bar");
-    mysql.format("baz");
-    mysql.query("SELECT NOW()", function () {});
-    mysql.execute("SELECT NOW()", function () {});
-    mysql.connection.end();
+    if (isMySQLConnection(app.mysql)) {
+      const mysql = app.mysql
+      mysql.escapeId("foo");
+      mysql.escape("bar");
+      mysql.format("baz");
+      mysql.query("SELECT NOW()", function () {});
+      mysql.execute("SELECT NOW()", function () {});
+      mysql.connection.end();
+    }
   });
 
 app
@@ -77,13 +87,15 @@ app
     connectionString: "mysql://root@localhost/mysql",
   })
   .after(async function (err) {
-    const mysql = app.mysql as MySQLPromiseConnection;
-    mysql.escapeId("foo");
-    mysql.escape("bar");
-    mysql.format("baz");
-    await mysql.query("SELECT NOW()");
-    await mysql.execute("SELECT NOW()");
-    mysql.connection.end();
+    if (isMySQLPromiseConnection(app.mysql)) {
+      const mysql = app.mysql
+      mysql.escapeId("foo");
+      mysql.escape("bar");
+      mysql.format("baz");
+      await mysql.query("SELECT NOW()");
+      await mysql.execute("SELECT NOW()");
+      mysql.connection.end();
+    }
   });
 
 app
@@ -93,10 +105,12 @@ app
     connectionString: "mysql://root@localhost/mysql",
   })
   .after(async function (err) {
-    const mysql = app.mysql as MySQLPromiseConnection;
-    const result = await mysql.connection.query<MySQLRowDataPacket[]>('SELECT NOW()');
-    expectType<MySQLRowDataPacket[]>(result[0]);
-    mysql.connection.end();
+    if (isMySQLPromiseConnection(app.mysql)) {
+      const mysql = app.mysql
+      const result = await mysql.connection.query<MySQLRowDataPacket[]>('SELECT NOW()');
+      expectType<MySQLRowDataPacket[]>(result[0]);
+      mysql.connection.end();
+    }
   });
 
 app
@@ -107,13 +121,15 @@ app
     multipleStatements: true,
   })
   .after(async function (err) {
-    const mysql = app.mysql as MySQLPromiseConnection;
-    const result = await mysql.connection.query<MySQLRowDataPacket[][]>(`
-      SELECT 1 + 1 AS test;
-      SELECT 2 + 2 AS test;
-    `);
-    expectType<MySQLRowDataPacket[][]>(result[0]);
-    mysql.connection.end();
+    if (isMySQLPromiseConnection(app.mysql)) {
+      const mysql = app.mysql
+      const result = await mysql.connection.query<MySQLRowDataPacket[][]>(`
+        SELECT 1 + 1 AS test;
+        SELECT 2 + 2 AS test;
+      `);
+      expectType<MySQLRowDataPacket[][]>(result[0]);
+      mysql.connection.end();
+    }
   });
 
 app
@@ -123,10 +139,12 @@ app
     connectionString: "mysql://root@localhost/mysql",
   })
   .after(async function (err) {
-    const mysql = app.mysql as MySQLPromiseConnection;
-    const result = await mysql.connection.query<MySQLResultSetHeader>('SET @1 = 1');
-    expectType<MySQLResultSetHeader>(result[0]);
-    mysql.connection.end();
+    if (isMySQLPromiseConnection(app.mysql)) {
+      const mysql = app.mysql
+      const result = await mysql.connection.query<MySQLResultSetHeader>('SET @1 = 1');
+      expectType<MySQLResultSetHeader>(result[0]);
+      mysql.connection.end();
+    }
   });
 
 app
@@ -137,32 +155,36 @@ app
     multipleStatements: true,
   })
   .after(async function (err) {
-    const mysql = app.mysql as MySQLPromiseConnection;
-    const result = await mysql.connection.query<MySQLResultSetHeader[]>(`
-      SET @1 = 1;
-      SET @2 = 2;
-    `);
-    expectType<MySQLResultSetHeader[]>(result[0]);
-    mysql.connection.end();
-  });
-
-app
-  .register(fastifyMysql, {
-    type: "connection",
-    promise: true,
-    connectionString: "mysql://root@localhost/mysql",
-  })
-  .after(async function (err) {
-    const mysql = app.mysql as MySQLPromiseConnection;
-    mysql.connection.query<MySQLResultSetHeader>('DROP PROCEDURE IF EXISTS myProcedure');
-    mysql.connection.query<MySQLResultSetHeader>(`
-      CREATE PROCEDURE myProcedure()
-      BEGIN
+    if (isMySQLPromiseConnection(app.mysql)) {
+      const mysql = app.mysql
+      const result = await mysql.connection.query<MySQLResultSetHeader[]>(`
         SET @1 = 1;
         SET @2 = 2;
-      END
-    `);
-    const result = await mysql.connection.query<MySQLProcedureCallPacket<MySQLResultSetHeader>>('CALL myProcedure()');
-    expectType<MySQLProcedureCallPacket<MySQLResultSetHeader>>(result[0]);
-    mysql.connection.end();
+      `);
+      expectType<MySQLResultSetHeader[]>(result[0]);
+      mysql.connection.end();
+    }
+  });
+
+app
+  .register(fastifyMysql, {
+    type: "connection",
+    promise: true,
+    connectionString: "mysql://root@localhost/mysql",
+  })
+  .after(async function (err) {
+    if (isMySQLPromiseConnection(app.mysql)) {
+      const mysql = app.mysql
+      mysql.connection.query<MySQLResultSetHeader>('DROP PROCEDURE IF EXISTS myProcedure');
+      mysql.connection.query<MySQLResultSetHeader>(`
+        CREATE PROCEDURE myProcedure()
+        BEGIN
+          SET @1 = 1;
+          SET @2 = 2;
+        END
+      `);
+      const result = await mysql.connection.query<MySQLProcedureCallPacket<MySQLResultSetHeader>>('CALL myProcedure()');
+      expectType<MySQLProcedureCallPacket<MySQLResultSetHeader>>(result[0]);
+      mysql.connection.end();
+    }
   });

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -4,7 +4,11 @@ import fastifyMysql, {
   MySQLPool,
   MySQLPromiseConnection,
   MySQLPromisePool,
+  MySQLProcedureCallPacket,
+  MySQLResultSetHeader,
+  MySQLRowDataPacket,
 } from "..";
+import {expectType} from 'tsd';
 
 declare module "fastify" {
   interface FastifyInstance {
@@ -79,5 +83,86 @@ app
     mysql.format("baz");
     await mysql.query("SELECT NOW()");
     await mysql.execute("SELECT NOW()");
+    mysql.connection.end();
+  });
+
+app
+  .register(fastifyMysql, {
+    type: "connection",
+    promise: true,
+    connectionString: "mysql://root@localhost/mysql",
+  })
+  .after(async function (err) {
+    const mysql = app.mysql as MySQLPromiseConnection;
+    const result = await mysql.connection.query<MySQLRowDataPacket[]>('SELECT NOW()');
+    expectType<MySQLRowDataPacket[]>(result[0]);
+    mysql.connection.end();
+  });
+
+app
+  .register(fastifyMysql, {
+    type: "connection",
+    promise: true,
+    connectionString: "mysql://root@localhost/mysql",
+    multipleStatements: true,
+  })
+  .after(async function (err) {
+    const mysql = app.mysql as MySQLPromiseConnection;
+    const result = await mysql.connection.query<MySQLRowDataPacket[][]>(`
+      SELECT 1 + 1 AS test;
+      SELECT 2 + 2 AS test;
+    `);
+    expectType<MySQLRowDataPacket[][]>(result[0]);
+    mysql.connection.end();
+  });
+
+app
+  .register(fastifyMysql, {
+    type: "connection",
+    promise: true,
+    connectionString: "mysql://root@localhost/mysql",
+  })
+  .after(async function (err) {
+    const mysql = app.mysql as MySQLPromiseConnection;
+    const result = await mysql.connection.query<MySQLResultSetHeader>('SET @1 = 1');
+    expectType<MySQLResultSetHeader>(result[0]);
+    mysql.connection.end();
+  });
+
+app
+  .register(fastifyMysql, {
+    type: "connection",
+    promise: true,
+    connectionString: "mysql://root@localhost/mysql",
+    multipleStatements: true,
+  })
+  .after(async function (err) {
+    const mysql = app.mysql as MySQLPromiseConnection;
+    const result = await mysql.connection.query<MySQLResultSetHeader[]>(`
+      SET @1 = 1;
+      SET @2 = 2;
+    `);
+    expectType<MySQLResultSetHeader[]>(result[0]);
+    mysql.connection.end();
+  });
+
+app
+  .register(fastifyMysql, {
+    type: "connection",
+    promise: true,
+    connectionString: "mysql://root@localhost/mysql",
+  })
+  .after(async function (err) {
+    const mysql = app.mysql as MySQLPromiseConnection;
+    mysql.connection.query<MySQLResultSetHeader>('DROP PROCEDURE IF EXISTS myProcedure');
+    mysql.connection.query<MySQLResultSetHeader>(`
+      CREATE PROCEDURE myProcedure()
+      BEGIN
+        SET @1 = 1;
+        SET @2 = 2;
+      END
+    `);
+    const result = await mysql.connection.query<MySQLProcedureCallPacket<MySQLResultSetHeader>>('CALL myProcedure()');
+    expectType<MySQLProcedureCallPacket<MySQLResultSetHeader>>(result[0]);
     mysql.connection.end();
   });

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -13,6 +13,9 @@ import fastifyMysql, {
   isMySQLPool,
 } from "..";
 import { expectType } from 'tsd';
+import { Pool } from "mysql2/typings/mysql/lib/Pool";
+import { Connection, PoolConnection } from "mysql2";
+import { Pool as PromisePool, Connection as PromiseConnection, PoolConnection as PromisePoolConnection } from "mysql2/promise";
 
 declare module "fastify" {
   interface FastifyInstance {
@@ -23,6 +26,10 @@ declare module "fastify" {
       | MySQLPromiseConnection;
   }
 }
+
+type PoolGetConnectionType = (callback: (err: NodeJS.ErrnoException | null, connection: PoolConnection) => any) => void;
+type PoolPromiseType = (promiseImpl?: PromiseConstructor) => PromisePool;
+type ConnectionPromiseType = (promiseImpl?: PromiseConstructor) => PromiseConnection;
 
 const app = fastify();
 app
@@ -41,6 +48,9 @@ app
         con.release();
       });
       mysql.pool.end();
+      expectType<PoolGetConnectionType>(app.mysql.getConnection);
+      expectType<Pool>(app.mysql.pool);
+      expectType<PoolPromiseType>(app.mysql.pool.promise);
     }
   });
 
@@ -60,6 +70,8 @@ app
       const con = await mysql.getConnection();
       con.release();
       mysql.pool.end();
+      expectType<() => Promise<PromisePoolConnection>>(app.mysql.getConnection);
+      expectType<PromisePool>(app.mysql.pool);
     }
   });
 
@@ -77,6 +89,9 @@ app
       mysql.query("SELECT NOW()", function () {});
       mysql.execute("SELECT NOW()", function () {});
       mysql.connection.end();
+      expectType<Connection>(app.mysql.connection);
+      expectType<ConnectionPromiseType>(app.mysql.connection.promise);
+      expectType<boolean>(app.mysql.connection.authorized);
     }
   });
 
@@ -95,6 +110,8 @@ app
       await mysql.query("SELECT NOW()");
       await mysql.execute("SELECT NOW()");
       mysql.connection.end();
+      expectType<PromiseConnection>(app.mysql.connection);
+      expectType<number>(app.mysql.connection.threadId);
     }
   });
 


### PR DESCRIPTION
#### Checklist

fixes: https://github.com/fastify/fastify-mysql/issues/127
This PR exports RowDataPacket, ResultSetHeader, ProcedureCallPacket from MySQL2 with prefix `MySQL` on the types

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
