### PR TITLE
docs: Add important disclaimer about using connectionString

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 
 Fastify MySQL connection plugin; with this you can share the same MySQL connection pool in every part of your server.
-Under the hood the [mysql2](https://github.com/sidorares/node-mysql2) is used. If you don't use the `connectionString` option, the options that you pass to `register` will be passed to the MySQL pool builder.
+Under the hood the [mysql2](https://github.com/sidorares/node-mysql2) is used. If you don't use the `connectionString` option, the options that you pass to `register` will be passed to the MySQL pool builder. 
+
+_Important:_ All MySQL2 options will be ignored when using `connectionString`, if you want to pass additional options to MySQL2 use `uri` instead of `connectionString`.
 
 ## Install
 ```


### PR DESCRIPTION
Add this important note, it's currently not clear unless you read your plugin code.

When using `connectionString` with fastify-mysql, it will NO longer pass any options towards mysql2. This could be confusing for some people.

If you however still want to use a database URI string together with additional mysql configuration options for the mysql2 package, then consider using `uri` option instead together with your additional options (let's say you also want to change `connectionLimit` as well and still use a database URI).

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
